### PR TITLE
change dependency of angular to 1.2.1 or above

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   ],
   "description": "if/elif/else directives for AngularJS",
   "dependencies": {
-    "angular": "1.2.16"
+    "angular": "^1.2.1"
   },
   "main": "src/elif.js",
   "keywords": [


### PR DESCRIPTION
1.2.1 is the minimum version that elif works with. Instead of requiring 1.2.16 exactly, allow bower to pick any version 1.2.1 or later. Also bower needs a tag on the commit to discover which version to use. See [Updating And Maintenance](http://bob.yexley.net/creating-and-maintaining-your-own-bower-package/#updatingandmaintenance)

Thank you!
