### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple collection of control flow directives: `ng-if`, `ng-else-if`, and `ng-else`.
 
-All directives support animations via `$animate`. `ng-if` can be used in on the same element as `ng-repeat`,
+All directives support animations via `$animate`. `ng-if` can be used on the same element as `ng-repeat`,
 just like the "real" `ng-if` that it overrides. The primary caveat is that a given if/else-if/else construct
 must exist in the same AngularJS scope (hence it doesn't make sense to say that either
 `ng-else-if` or `ng-else` work with `ng-repeat`, as `ng-repeat` introduces a new


### PR DESCRIPTION
Line 5 had a superfluous "in" between "used" and "on."  This change removes the "in" to improve the clarity of the sentence.  No other changes were made.

Before: ...can be used in on the same element...
After: ...can be used on the same element...
