### PR TITLE
Fixed "Cannot read property 'ngIf' of undefined" when using ng-elif within a test suite.

### DIFF
--- a/src/elif.js
+++ b/src/elif.js
@@ -126,7 +126,7 @@
       '$injector',
       'elif',
       function($animate, $document, $injector, elif){
-        getter = getter && $injector.invoke(getter);
+        var getterFn = getter && $injector.invoke(getter);
         
         return {
           transclude: 'element',
@@ -134,7 +134,7 @@
           priorty: 600,
           terminal: true,
           link: function(scope, element, attrs, ctrls, transcludeFn){
-            var watchFn = getter && getter(scope, element, attrs);
+            var watchFn = getterFn && getterFn(scope, element, attrs);
             var childScope;
             var childElement;
             var previousElements;
@@ -195,11 +195,11 @@
     '$injector',
     'elif',
     function($injector, elif){
-      getter = $injector.invoke(getter('ngIf'));
+      getterFn = $injector.invoke(getter('ngIf'));
       return {
         priority: 600,
         link: function(scope, element, attrs){
-          var watchFn = getter(scope, element, attrs);
+          var watchFn = getterFn(scope, element, attrs);
           elif.create(scope, watchFn);
         }
       }


### PR DESCRIPTION
I'm using ng-elif in my project and when I run the test suite I get "Cannot read property 'ngIf' of undefined". The change I made to fix this involves splitting out `getter` to `getter` (the original var), and `getterFn` (what gets assigned when running `$injector.invoke(getter)`. There doesn't seem to be any runtime changes in behavior and my app uses ng-else-if and ng-else quite a bit.

Thanks for the awesome directive!