### PR TITLE
Move gulp to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-elif",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "if/elif/else directives for AngularJS",
   "main": "src/elif.js",
   "repository": {
@@ -8,9 +8,9 @@
     "url": "https://github.com/zachsnow/ng-elif.git"
   },
   "dependencies": {
-    "gulp": "^3.8.11"
   },
   "devDependencies": {
+    "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",
     "gulp-jshint": "^1.9.4",
     "gulp-karma": "0.0.4",


### PR DESCRIPTION
Hey, I'm sure this package isn't top of mind for you lately, but my team still uses it and loves it.

There's an open CVE on `lodash` that (by a long chain of dependencies) is required by this version of `gulp`. This seemed like a reasonable compromise to me, we can still run that version of gulp on local when maintaining the package, but it doesn't need to be compiled into my shipping asset.

LMK if this works for you and you can merge it up, otherwise I can keep using my fork until we finally axe Angular 1.

Thanks again for this package, it's such a clever fluent addition I've always really appreciated it.